### PR TITLE
Fix fetch spec and throw a proper error object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,11 @@
 var exports = module.exports;
 
-function fetchReject(...params) {
-  return fetch(params)
-    .then(handleErrors)
-}
-
 function handleErrors(response) {
   if (response.ok) {
     return response;
   }
   
-  throw response.statusText;
+  throw Error(response.statusText);
 }
 
-exports = fetchReject;
+exports = (input, init) => fetch(input, init).then(handleErrors);


### PR DESCRIPTION
Fetch takes 2 arguments calling fetch with the params object directly make it so the init is never passed indvidualy which make it so this fetch-reject isn't behaving exactly like fetch.

Also throw a proper error object
